### PR TITLE
ENH: Send download link

### DIFF
--- a/static/public/scripts/directives/directiveJobStatus.js
+++ b/static/public/scripts/directives/directiveJobStatus.js
@@ -1,5 +1,5 @@
 angular.module('CIVILITY')
-.directive('jobStatus', function($routeParams,$location,clusterpost, $http){
+.directive('jobStatus', function($routeParams,$location,clusterpost, $window){
 
 	function link($scope,$attrs,$filter){
 
@@ -124,6 +124,16 @@ angular.module('CIVILITY')
         pom.dataset.downloadurl = ['text/plain', pom.download, pom.href].join(':');
         pom.click();        */
       });
+    }
+
+    $scope.getOutputDirectoryURL = function(jobid, name)
+    {
+
+      clusterpost.getAttachmentURL(jobid, name)
+      .then(function(url){        
+        $window.open(url, '_blank');
+      });
+      
     }
 
 		//Get job document information 

--- a/static/public/scripts/directives/directiveJobStatus.js
+++ b/static/public/scripts/directives/directiveJobStatus.js
@@ -129,9 +129,12 @@ angular.module('CIVILITY')
     $scope.getOutputDirectoryURL = function(jobid, name)
     {
 
-      clusterpost.getAttachmentURL(jobid, name)
-      .then(function(url){        
-        $window.open(url, '_blank');
+      clusterpost.getDownloadToken(jobid, name)
+      .then(function(res){        
+        $window.open("/dataprovider/download/" + res.data.token, '_blank');
+      })
+      .catch(function(err){
+        console.error(err);
       });
       
     }

--- a/static/public/services/cluster.service.js
+++ b/static/public/services/cluster.service.js
@@ -68,7 +68,7 @@ angular.module('CIVILITY')
         responseType: responseType
       });
     },
-    getAttachmentURL: function(id, name){
+    getDownloadToken: function(id, name){
       return $http({
         method: 'GET',
         url: '/dataprovider/download/' + id + '/' + encodeURIComponent(name)

--- a/static/public/services/cluster.service.js
+++ b/static/public/services/cluster.service.js
@@ -68,6 +68,12 @@ angular.module('CIVILITY')
         responseType: responseType
       });
     },
+    getAttachmentURL: function(id, name){
+      return $http({
+        method: 'GET',
+        url: '/dataprovider/download/' + id + '/' + encodeURIComponent(name)
+      });      
+    },
     addAttachment: function(id, filename, data){
     	return $http({
         method: 'PUT',

--- a/static/public/views/directives/directiveJobStatus.html
+++ b/static/public/views/directives/directiveJobStatus.html
@@ -19,7 +19,7 @@
 		</div>
 
 		<div class="divLinkDir"> 
-	 		<a class="linkDownloadDir" href="" ng-click="getOutputDirectory(jobId,jobObject.outputs[2].name+'.tar.gz')"> Download output directory </a><br>
+	 		<a class="linkDownloadDir" href="" ng-click="getOutputDirectoryURL(jobId,jobObject.outputs[2].name)" target="_blank"> Download output directory </a><br>
 	 	</div>
 	 </div>
 	


### PR DESCRIPTION
JWT are stateless. Send temporary token for file download and enable anchor tag authentication. 
The token can be embedded in the URL and may go into the browser history and server logs since it will only be valid for a short amount of time. 
